### PR TITLE
Feature/sf 28 mod

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -158,7 +158,7 @@ class AdminController extends Controller
         if (is_null($templateFile) === false) {
             $content->setTemplateFile($templateFile);
         }
-        $contentFormType = $this->getClassLoader()->getContentFormTypeFQCN();
+        $contentFormType = $this->getClassLoader()->getContentFormType();
 
         return  $this->createForm($contentFormType, $content);
     }

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -158,7 +158,7 @@ class AdminController extends Controller
         if (is_null($templateFile) === false) {
             $content->setTemplateFile($templateFile);
         }
-        $contentFormType = $this->getClassLoader()->getContentFormType();
+        $contentFormType = $this->getClassLoader()->getContentFormTypeFQCN();
 
         return  $this->createForm($contentFormType, $content);
     }

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -33,7 +33,7 @@ class AdminController extends Controller
     public function listAction(Request $request)
     {
         $contentsList = $this->getContentManager()->retrieveContentsList();
-        $baseUrl = $this->getBaseUrl();
+        $baseUrl = $this->getBaseUrl($request);
 
         return ['contentsList' => $contentsList, 'baseUrl' => $baseUrl];
     }
@@ -52,7 +52,6 @@ class AdminController extends Controller
         if ($templateFile === '') {
             return $this->forward('WizinSimpleCmsBundle:Admin:selectTemplateFile');
         }
-        $request = $this->container->get('request_stack')->getCurrentRequest();
         $entityClass = $this->getClassLoader()->getContentRepository()->getClassName();
         /** @var \Wizin\Bundle\SimpleCmsBundle\Entity\ContentInterface $content */
         $content = new $entityClass();
@@ -195,7 +194,6 @@ class AdminController extends Controller
     protected function save(Request $request, ContentInterface $content, Form $form)
     {
         $result = false;
-        $request = $this->container->get('request_stack')->getCurrentRequest();
         $form->handleRequest($request);
         if ($form->isValid()) {
             try {
@@ -214,12 +212,11 @@ class AdminController extends Controller
     }
 
     /**
+     * @param Request $request
      * @return mixed|string
      */
-    protected function getBaseUrl()
+    protected function getBaseUrl(Request $request)
     {
-        $request = $this->container->get('request_stack')->getCurrentRequest();
-
         $baseUrl = $this->container->getParameter('wizin_simple_cms.base_url');
         if (is_null($baseUrl)) {
             $baseUrl = preg_replace(

--- a/Form/ContentType.php
+++ b/Form/ContentType.php
@@ -26,11 +26,4 @@ class ContentType extends AbstractType
         $builder->add('draft', Type\SubmitType::class, ['validation_groups' => false]);
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'Content';
-    }
 }

--- a/Form/ContentType.php
+++ b/Form/ContentType.php
@@ -19,8 +19,8 @@ class ContentType extends AbstractType
         $builder->add('id', Type\HiddenType::class);
         $builder->add('pathInfo', Type\TextType::class);
         $builder->add('title', Type\TextType::class);
-        $builder->add('parameters', Type\CollectionType::class, ['type' => 'textarea', 'required' => false]);
-        $builder->add('templateFile', Type\TextType::class, ['read_only' => true]);
+        $builder->add('parameters', Type\CollectionType::class, ['entry_type' => Type\TextareaType::class, 'required' => false]);
+        $builder->add('templateFile', Type\TextType::class, ['attr' => ['readonly' => true]]);
         $builder->add('active', Type\CheckboxType::class, ['required' => false]);
         $builder->add('save', Type\SubmitType::class, ['validation_groups' => false]);
         $builder->add('draft', Type\SubmitType::class, ['validation_groups' => false]);

--- a/Service/ClassLoader.php
+++ b/Service/ClassLoader.php
@@ -36,4 +36,12 @@ class ClassLoader extends Service
     {
         return new ContentType();
     }
+
+    /**
+     * @return string
+     */
+    public function getContentFormTypeFQCN()
+    {
+        return ContentType::class;
+    }
 }

--- a/Service/ClassLoader.php
+++ b/Service/ClassLoader.php
@@ -30,17 +30,9 @@ class ClassLoader extends Service
     }
 
     /**
-     * @return \Wizin\Bundle\SimpleCmsBundle\Form\ContentType
-     */
-    public function getContentFormType()
-    {
-        return new ContentType();
-    }
-
-    /**
      * @return string
      */
-    public function getContentFormTypeFQCN()
+    public function getContentFormType()
     {
         return ContentType::class;
     }


### PR DESCRIPTION
sf28への対応群です。
・formtypeのdeprecation
　・CollectionTypeにおける属性 'type' を 'entry_type' に、また参照先formtypeを名前でなくFQCNに
　・'read_only' 属性非推奨化によって 'read_only' を 'attr' => ['readonly'] に
　・getContentFormType　のreturnをinstanceからFQCNに　☆
・controller::getRequest() や container->get('request') のdeprecation
　・各actionでRequestを受け取るようにsignatureを変更　☆
　・actionから呼ばれる一部methodでRequestを受け取るように変更　☆
　・getRequest()をなくし、降ってくるrequestを使うように変更

backward compatibilityを壊す対応が含まれます。(☆マーク)

また、本bundle観点では必要としていないactionにもRequest受けを明示した関係で、
IDEには「未使用の引数が定義されている」といわれるようになりました。
これはこれらactionについてoverrideする側の子bundleがrequestを使いたくなった場合を想定しての対応になります。

ご確認お願いします。